### PR TITLE
Use pkg-config + small change

### DIFF
--- a/bgs.c
+++ b/bgs.c
@@ -238,8 +238,9 @@ main(int argc, char *argv[]) {
 		case 'R':
 			rotate = False; break;
 		case 'v':
-			die("bgs-"VERSION", © 2010 bgs engineers, see"
+			printf("bgs-"VERSION", © 2010 bgs engineers, see "
 					"LICENSE for details\n");
+			return 0;
 		case 'x':
 			running = True; break;
 		case 'z':

--- a/config.mk
+++ b/config.mk
@@ -7,22 +7,17 @@ VERSION = 0.7.1
 PREFIX = /usr/local
 MANPREFIX = ${PREFIX}/share/man
 
-X11INC = /usr/X11R6/include
-X11LIB = /usr/X11R6/lib
-
-IMLIB2INC = /usr/include/imlib2
-IMLIB2LIB = /usr/lib/imlib2/
-
 # Xinerama, comment if you don't want it
-XINERAMALIBS = -L${X11LIB} -lXinerama
+XINERAMALIBS = -lXinerama
 XINERAMAFLAGS = -DXINERAMA
 
 # includes and libs
-INCS = -I${X11INC} -I ${IMLIB2INC}
-LIBS = -lm -L${X11LIB} -lX11 ${XINERAMALIBS} -L${IMLIB2LIB} -lImlib2 -lm
+INCS = `pkg-config --cflags imlib2`
+LIBS = `pkg-config --libs imlib2` ${XINERAMALIBS}
 
 # flags
-CFLAGS += -std=c99 -pedantic -Wall ${INCS} -DVERSION=\"${VERSION}\" ${XINERAMAFLAGS}
+CPPFLAGS += -DVERSION=\"${VERSION}\" ${XINERAMAFLAGS}
+CFLAGS += -std=c99 -pedantic -Wall ${INCS} ${CPPFLAGS}
 LDFLAGS += ${LIBS}
 
 # compiler and linker


### PR DESCRIPTION
The first commit allows me to compile bgs without fiddling around with config.mk (on OpenBSD).
I'm not sure if you want to support systems lacking pkg-config, so I'll drop the first change if you want.